### PR TITLE
Add support for 'inline' checkbox and radio choices

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -220,3 +220,14 @@ or ``input_append`` as keyword arguments to the widget constructor in your
               input_append="kg",
               css_class="span1",
           ))
+
+bootstrap_form_style
+--------------------
+
+Bootstrap supports `four form styles`__.  By default, ``deform_bootstrap``
+uses the ``.form-horizontal`` style.  You can specify one of the other
+styles be setting the ``bootstrap_form_style`` attribute of your ``Form``::
+
+  myform = Form(myschema, bootstrap_form_style='form-vertical')
+
+__ http://twitter.github.com/bootstrap/base-css.html#forms

--- a/README.rst
+++ b/README.rst
@@ -231,3 +231,20 @@ styles be setting the ``bootstrap_form_style`` attribute of your ``Form``::
   myform = Form(myschema, bootstrap_form_style='form-vertical')
 
 __ http://twitter.github.com/bootstrap/base-css.html#forms
+
+inline
+------
+
+Bootstrap supports inline checkbox and radio choices.  Normally
+``RadioChoiceWidget``\s and ``CheckboxChoiceWidgets``\s are displayed
+with one choice per line.  To select the inline style, set the
+``inline`` attribute of the choice widget to a trueish value::
+
+  class MySchema(colander.Schema):
+      choice = colander.SchemaNode(
+          colander.String(),
+          widget=deform.widget.CheckboxChoiceWidget(
+              values=[(u'a', u'Apple'),
+                      (u'b', u'Bear'),
+                      (u'c', u'Computer')],
+              inline=True))

--- a/deform_bootstrap/demo/__init__.py
+++ b/deform_bootstrap/demo/__init__.py
@@ -130,3 +130,36 @@ class DeformBootstrapDemo(DeformDemo):
         form = deform.Form(schema, buttons=('submit',))
         return self.render_form(form)
 
+    @view_config(renderer='deformdemo:templates/form.pt',
+                 name='inline_radiochoice')
+    @demonstrate('Inline RadioChoice Widget')
+    def inline_radiochoice(self):
+        class Schema(colander.Schema):
+            choice = colander.SchemaNode(
+                colander.String(),
+                widget=deform.widget.RadioChoiceWidget(
+                    values=[('a', 'Arrow'),
+                            ('b', 'Brick'),
+                            ('c', 'Cardamom')],
+                    inline=True),
+                description='Pick one')
+        schema = Schema()
+        form = deform.Form(schema, buttons=('submit',))
+        return self.render_form(form)
+
+    @view_config(renderer='deformdemo:templates/form.pt',
+                 name='inline_checkboxchoice')
+    @demonstrate('Inline CheckboxChoice Widget')
+    def inline_checkboxchoice(self):
+        class Schema(colander.Schema):
+            choice = colander.SchemaNode(
+                deform.schema.Set(),
+                widget=deform.widget.CheckboxChoiceWidget(
+                    values=[('a', 'Awesome'),
+                            ('b', 'Bogus'),
+                            ('c', 'Crud')],
+                    inline=True),
+                description='Pick as many as apply')
+        schema = Schema()
+        form = deform.Form(schema, buttons=('submit',))
+        return self.render_form(form)

--- a/deform_bootstrap/templates/checkbox_choice.pt
+++ b/deform_bootstrap/templates/checkbox_choice.pt
@@ -1,15 +1,17 @@
 <input type="hidden" name="__start__" value="${field.name}:sequence"/>
   <tal:loop tal:repeat="choice field.widget.values">
-    <tal:def tal:define="(value, title) choice">
-        <label class="checkbox" for="${field.oid}-${repeat.choice.index}">
-          <input tal:attributes="checked value in cstruct;
-                                 class field.widget.css_class"
-                 type="checkbox"
-                 name="checkbox"
-                 value="${value}"
-                 id="${field.oid}-${repeat.choice.index}"/>
-          ${title}
-        </label>
+    <tal:def tal:define="(value, title) choice;
+                         inline getattr(field.widget, 'inline', False);
+                         label_class inline and 'checkbox inline' or 'checkbox'">
+      <label class="${label_class}" for="${field.oid}-${repeat.choice.index}">
+        <input tal:attributes="checked value in cstruct;
+                               class field.widget.css_class"
+               type="checkbox"
+               name="checkbox"
+               value="${value}"
+               id="${field.oid}-${repeat.choice.index}"/>
+        ${title}
+      </label>
     </tal:def>
   </tal:loop>
 <input type="hidden" name="__end__" value="${field.name}:sequence"/>

--- a/deform_bootstrap/templates/radio_choice.pt
+++ b/deform_bootstrap/templates/radio_choice.pt
@@ -1,17 +1,17 @@
 <input type="hidden" name="__start__" value="${field.name}:rename"/>
 <tal:loop tal:repeat="choice field.widget.values">
-  <tal:def tal:define="(value, title) choice">
-    <div class="deformSet-item">
-      <label class="radio" for="${field.oid}-${repeat.choice.index}">
-        <input tal:attributes="checked value == cstruct;
-                               class field.widget.css_class"
-               type="radio"
-               name="${field.oid}"
-               value="${value}"
-               id="${field.oid}-${repeat.choice.index}"/>
-        ${title}
-      </label>
-    </div>
+  <tal:def tal:define="(value, title) choice;
+                       inline getattr(field.widget, 'inline', False);
+                       label_class inline and 'radio inline' or 'radio'">
+    <label class="${label_class}" for="${field.oid}-${repeat.choice.index}">
+      <input tal:attributes="checked value == cstruct;
+                             class field.widget.css_class"
+             type="radio"
+             name="${field.oid}"
+             value="${value}"
+             id="${field.oid}-${repeat.choice.index}"/>
+      ${title}
+    </label>
   </tal:def>
 </tal:loop>
 <input type="hidden" name="__end__"/>


### PR DESCRIPTION
Great work on deform_bootstrap!

Here are two small patches.  The first adds documentation on the `Form.bootstrap_form_style` attribute.  The second adds support for `CheckboxChoiceWidget.inline` and `RadioChoiceWidget.inline` attributes to display the choices inline as opposed to one per line.

(Sorry, I can't get the selenium tests to pass here right now.  It might have to do with the fact that I am running python 2.6; or it could just be because I'm clueless about selenium.  In any case, since I can't get the tests to pass on a clean codebase, I have not written tests for my changes.)
