### PR TITLE
Datepicker nit fix

### DIFF
--- a/deform_bootstrap/static/bootstrap-datepicker.js
+++ b/deform_bootstrap/static/bootstrap-datepicker.js
@@ -204,7 +204,7 @@
         // Hide all other datepickers.
         clearDatePickers(this);
 
-        var offset = this.$el.offset();
+        var offset = this.$el.position();
 
         this.$picker.css({
           top: offset.top + this.$el.outerHeight() + 2,


### PR DESCRIPTION
Without this, if the offset parent of the datepicker input is not the document, the calendar widget gets positioned incorrectly (e.g. often somewhere off the screen.)
