### PR TITLE
Add compiled version of datepicker.less

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -130,10 +130,17 @@ CSS
   This file contains a small fix for conflicts between chosen and bootstrap.
   Only needed if you make use of chosen, but harmless if you don't.
 
+``bootstrap-datepicker.css``
+  The styles for the *native* bootstrap datepicker widget (see above).
+
+Note that ``chosen_bootstrap.css`` and ``bootstrap-datepicker.css``
+are included in ``deform_bootstrap.css``, so you will only need them
+if you use some other version of the bootstrap css.
+
 JS
 --
 
-``bootstrap_datepicker.js``
+``bootstrap-datepicker.js``
   Only needed if you want to use the *native* bootstrap datepicker widget
   (see above).
 

--- a/deform_bootstrap/static/bootstrap-datepicker.css
+++ b/deform_bootstrap/static/bootstrap-datepicker.css
@@ -1,0 +1,141 @@
+.clearfix {
+  *zoom: 1;
+}
+.clearfix:before,
+.clearfix:after {
+  display: table;
+  content: "";
+}
+.clearfix:after {
+  clear: both;
+}
+.datepicker {
+  background-color: #ffffff;
+  border-color: #999;
+  border-color: rgba(0, 0, 0, 0.2);
+  border-style: solid;
+  border-width: 1px;
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
+  border-radius: 4px;
+  -webkit-box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  -moz-box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  -webkit-background-clip: padding-box;
+  -moz-background-clip: padding-box;
+  background-clip: padding-box;
+  display: none;
+  position: absolute;
+  z-index: 900;
+  margin-left: 0;
+  margin-right: 0;
+  margin-bottom: 18px;
+  padding-bottom: 4px;
+  width: 218px;
+}
+.datepicker .nav {
+  font-weight: bold;
+  width: 100%;
+  padding: 4px 0;
+  background-color: #f5f5f5;
+  color: #555555;
+  border-bottom: 1px solid #ddd;
+  -webkit-box-shadow: inset 0 1px 0 #ffffff;
+  -moz-box-shadow: inset 0 1px 0 #ffffff;
+  box-shadow: inset 0 1px 0 #ffffff;
+  *zoom: 1;
+}
+.datepicker .nav:before,
+.datepicker .nav:after {
+  display: table;
+  content: "";
+}
+.datepicker .nav:after {
+  clear: both;
+}
+.datepicker .nav span {
+  display: block;
+  float: left;
+  text-align: center;
+  height: 28px;
+  line-height: 28px;
+  position: relative;
+}
+.datepicker .nav .bg {
+  width: 100%;
+  background-color: #fdf5d9;
+  height: 28px;
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
+  border-radius: 4px;
+}
+.datepicker .nav .fg {
+  width: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+.datepicker .button {
+  cursor: pointer;
+  padding: 0 4px;
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
+  border-radius: 4px;
+}
+.datepicker .button:hover {
+  background-color: #555555;
+  color: #ffffff;
+}
+.datepicker .months {
+  float: left;
+  margin-left: 4px;
+}
+.datepicker .months .name {
+  width: 72px;
+  padding: 0;
+}
+.datepicker .years {
+  float: right;
+  margin-right: 4px;
+}
+.datepicker .years .name {
+  width: 36px;
+  padding: 0;
+}
+.datepicker .dow,
+.datepicker .days div {
+  float: left;
+  width: 30px;
+  line-height: 25px;
+  text-align: center;
+}
+.datepicker .dow {
+  font-weight: bold;
+  color: #555555;
+}
+.datepicker .calendar {
+  padding: 4px;
+}
+.datepicker .days div {
+  cursor: pointer;
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
+  border-radius: 4px;
+}
+.datepicker .days div:hover {
+  background-color: #0064cd;
+  color: #ffffff;
+}
+.datepicker .overlap {
+  color: #999999;
+}
+.datepicker .today {
+  background-color: #fee9cc;
+}
+.datepicker .selected {
+  background-color: #999999;
+  color: #ffffff;
+}

--- a/deform_bootstrap/static/bootstrap-datepicker.less
+++ b/deform_bootstrap/static/bootstrap-datepicker.less
@@ -1,0 +1,4 @@
+@import "twitter_bootstrap/less/variables.less";
+@import "twitter_bootstrap/less/mixins.less";
+@import "datepicker.less";
+


### PR DESCRIPTION
This adds a compiled version of `datepicker.less` for those who want the datepicker styles, but are using some other version of `bootstrap.css` (and so neither want the whole `deform_bootstrap.css`, nor want to compile `datepicker.less` themselves.)
