### PR TITLE
Added the alert class to the mapping template

### DIFF
--- a/deform_bootstrap/templates/mapping.pt
+++ b/deform_bootstrap/templates/mapping.pt
@@ -4,7 +4,7 @@
 
   <legend tal:condition="field.title">${field.title}</legend>
 
-  <div class="clearfix alert-message error" tal:condition="field.errormsg">
+  <div class="clearfix alert alert-message error" tal:condition="field.errormsg">
     <p i18n:translate="">
       There was a problem with this section
     </p>


### PR DESCRIPTION
The mapping template was missing the alert class so validation errors on mappings were not styled as an alert.
