### PR TITLE
The field's description is showed even if its field widget is HiddenWidget

### DIFF
--- a/deform_bootstrap/templates/mapping_item.pt
+++ b/deform_bootstrap/templates/mapping_item.pt
@@ -39,7 +39,7 @@
         </span>
       </span>
 
-      <span class="help-block" tal:condition="field.description">
+      <span class="help-block" tal:condition="field.description and not field.widget.hidden">
         ${field.description}
       </span>
     </div>


### PR DESCRIPTION
It's a minor bug. Firstly, read this: https://github.com/Pylons/Kotti/issues/111 .
