### PR TITLE
A button would appear disabled, if button.disabled==False

### DIFF
--- a/deform_bootstrap/__init__.py
+++ b/deform_bootstrap/__init__.py
@@ -1,5 +1,4 @@
 from pkg_resources import resource_filename
-
 from deform import Form
 
 
@@ -12,4 +11,5 @@ def add_search_path():
 
 def includeme(config):
     add_search_path()
-    config.add_static_view('static-deform_bootstrap', 'deform_bootstrap:static')
+    config.add_static_view('static-deform_bootstrap',
+        'deform_bootstrap:static')

--- a/deform_bootstrap/templates/checkbox.pt
+++ b/deform_bootstrap/templates/checkbox.pt
@@ -1,0 +1,7 @@
+<input type="checkbox"
+  name="${field.name}" value="${field.widget.true_val}"
+  id="${field.oid}"
+  tal:attributes="checked cstruct == field.widget.true_val;
+                  class field.widget.css_class" />
+<label tal:condition="hasattr(field.schema, 'text')" for="${field.oid}"
+  tal:content="field.schema.text" class="checkbox-label" />

--- a/deform_bootstrap/templates/form.pt
+++ b/deform_bootstrap/templates/form.pt
@@ -9,7 +9,6 @@
   i18n:domain="deform">
 
   <fieldset>
-
     <legend tal:condition="field.title">${field.title}</legend>
 
     <input type="hidden" name="_charset_" />
@@ -36,7 +35,7 @@
     <div class="form-actions">
       <tal:block repeat="button field.buttons">
         <button
-            tal:attributes="disabled button.disabled"
+            tal:attributes="disabled button.disabled or None"
             id="${field.formid+button.name}"
             name="${button.name}"
             type="${button.type}"
@@ -66,5 +65,5 @@
        }
     );
   </script>
-  
+
 </form>

--- a/deform_bootstrap/widget.py
+++ b/deform_bootstrap/widget.py
@@ -3,7 +3,7 @@ from colander import null, Invalid
 from deform.i18n import _
 from deform.widget import AutocompleteInputWidget, SelectWidget, Widget
 from deform.widget import DateTimeInputWidget as DateTimeInputWidgetBase
-from deform.widget import default_resource_registry
+# from deform.widget import default_resource_registry
 
 
 class TypeaheadInputWidget(AutocompleteInputWidget):
@@ -42,7 +42,6 @@ class TypeaheadInputWidget(AutocompleteInputWidget):
     items
         The max number of items to display in the dropdown. Defaults to
         ``8``.
-
     """
     readonly_template = 'readonly/textinput'
     size = None
@@ -65,7 +64,6 @@ class TypeaheadInputWidget(AutocompleteInputWidget):
 
 
 class DateTimeInputWidget(DateTimeInputWidgetBase):
-
     template = 'splitted_datetimeinput'
     readonly_template = 'readonly/textinput'
     requirements = ()
@@ -109,8 +107,10 @@ class DateTimeInputWidget(DateTimeInputWidgetBase):
 class ChosenSingleWidget(SelectWidget):
     template = 'chosen_single'
 
+
 class ChosenOptGroupWidget(SelectWidget):
     template = 'chosen_optgroup'
+
 
 class ChosenMultipleWidget(Widget):
     template = 'chosen_multiple'
@@ -129,4 +129,3 @@ class ChosenMultipleWidget(Widget):
         if isinstance(pstruct, basestring):
             return (pstruct,)
         return tuple(pstruct)
-


### PR DESCRIPTION
If, when the template is rendered, button.disabled is False, then a disabled="" attribute is rendered, which is enough to disable the submit button.
To avoid this, I am using this code:

tal:attributes="disabled button.disabled or None"

I added a second commit by accident; it is a new feature which should be in a different pull request. If you want me to, I can redo the whole thing as 2 separate pull requests... Just let me know.
