### PR TITLE
Support standard HTML attributes in text inputs

### DIFF
--- a/deform_bootstrap/templates/password.pt
+++ b/deform_bootstrap/templates/password.pt
@@ -1,0 +1,7 @@
+<input type="password" name="${field.name}" value="${cstruct}"
+  tal:attributes="class field.widget.css_class;
+              maxlength getattr(field.widget, 'maxlength', None);
+            placeholder getattr(field.widget, 'placeholder', None);
+               required 'true' if field.required else None;
+                   size field.widget.size;"
+  id="${field.oid}"/>

--- a/deform_bootstrap/templates/textarea.pt
+++ b/deform_bootstrap/templates/textarea.pt
@@ -1,0 +1,9 @@
+<textarea tal:attributes="
+              id field.oid;
+            name field.name;
+           class field.widget.css_class;
+            cols field.widget.cols;
+           rows field.widget.rows;
+     maxlength getattr(field.widget, 'maxlength', None);
+  placeholder getattr(field.widget, 'placeholder', None);
+    required 'true' if field.required else None;">${cstruct}</textarea>

--- a/deform_bootstrap/templates/textinput.pt
+++ b/deform_bootstrap/templates/textinput.pt
@@ -1,0 +1,21 @@
+<span tal:omit-tag="">
+  <input tal:attributes="
+          class field.widget.css_class;
+             id field.oid;
+      maxlength getattr(field.widget, 'maxlength', None);
+           name field.name;
+    placeholder getattr(field.widget, 'placeholder', None);
+       required 'required' if field.required else None;
+           size field.widget.size;
+           type getattr(field.widget, 'type', 'text');
+          value cstruct or None;
+  " />
+  <script tal:condition="field.widget.mask" type="text/javascript">
+    deform.addCallback(
+      '${field.oid}',
+      function (oid) {
+        $("#" + oid).mask("${field.widget.mask}",
+                          {placeholder:"${field.widget.mask_placeholder}"});
+      });
+  </script>
+</span>


### PR DESCRIPTION
- Supports the _maxlength_ attribute via widget.maxlength
- Supports the HTML5 _placeholder_ attribute via widget.placeholder
- Sets the HTML5 required="required" attribute if field.required
