### PR TITLE
Chameleon breaks on ↕ in sequence_item.pt

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,8 @@ CHANGES
 - Add remote source for TypeAheadInputWidget,
  'source' attribute renamed to 'values'
 
+- Fixed `sequence_item.pt` not to break in Chameleon.
+
 0.2.4 - 2012-10-24
 ------------------
 

--- a/deform_bootstrap/templates/sequence_item.pt
+++ b/deform_bootstrap/templates/sequence_item.pt
@@ -14,7 +14,7 @@
 
 <style>
     .deformOrderbuttonActive:before {
-        content:"↕";
+        content:"&#x2195;";
         margin-right: 5px;
     }
 </style>

--- a/deform_bootstrap/templates/sequence_item.pt
+++ b/deform_bootstrap/templates/sequence_item.pt
@@ -14,7 +14,7 @@
 
 <style>
     .deformOrderbuttonActive:before {
-        content:"&#x2195;";
+        content:"\2195";
         margin-right: 5px;
     }
 </style>


### PR DESCRIPTION
Chameleon 2.9 up to 2.11 breaks with the following exception when a sequence item is displayed:

```
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 2700: ordinal not in range(128)
```

The character on pos 2700 is ↕ in sequence_item.pt. I replaced it with a notation vaild for CSS where Chameleon does not barf.

Btw I'm using Pyramid 1.4a4.
