### PR TITLE
Omit the `div.form-actions` tag from inline forms.

### DIFF
--- a/deform_bootstrap/templates/form.pt
+++ b/deform_bootstrap/templates/form.pt
@@ -6,8 +6,9 @@
   method="${field.method}"
   enctype="multipart/form-data"
   accept-charset="utf-8"
-  i18n:domain="deform">
-
+  i18n:domain="deform"
+  tal:define="inline field.bootstrap_form_style == 'form-inline'">
+  
   <fieldset>
 
     <legend tal:condition="field.title">${field.title}</legend>
@@ -33,7 +34,7 @@
         tal:replace="structure
                      rndr(tmpl,field=f,cstruct=cstruct.get(f.name, null))" />
 
-    <div tal:condition="field.buttons" class="form-actions">
+    <div tal:condition="field.buttons" tal:omit-tag="inline" class="form-actions">
       <tal:block repeat="button field.buttons">
         <button
             tal:attributes="disabled button.disabled"


### PR DESCRIPTION
To render an inline-form, it's current possible to pass in:
- `bootstrap_form_style=form-inline` to the form constructor
- `category=structural` / `inline=True` to your widget constructor(s)

However, it's not currently possible to pass in a kwarg to stop rendering the `div.form-actions` container around your buttons, as per the markup recommended by the bootstrap "Inline Form" docs: http://twitter.github.com/bootstrap/base-css.html#forms

This patch fixes the issue by `tal:omit-tag`ing the div.form-actions element if `field.bootstrap_form_style == 'form-inline'`.
