### PR TITLE
Re: #42 fix bug when `bootstrap_form_style` not provided.

### DIFF
--- a/deform_bootstrap/templates/form.pt
+++ b/deform_bootstrap/templates/form.pt
@@ -7,7 +7,7 @@
   enctype="multipart/form-data"
   accept-charset="utf-8"
   i18n:domain="deform"
-  tal:define="inline field.bootstrap_form_style == 'form-inline'">
+  tal:define="inline getattr(field, 'bootstrap_form_style', None) == 'form-inline'">
   
   <fieldset>
 

--- a/deform_bootstrap/templates/typeahead_input.pt
+++ b/deform_bootstrap/templates/typeahead_input.pt
@@ -10,7 +10,8 @@
            data-provide="typeahead"
            tal:attributes="size size;
                            class css_class;
-                           style style"
+                           style style;
+                           placeholder getattr(field.widget, 'placeholder', nothing)"
            id="${oid}"/>
     <script tal:condition="field.widget.values" type="text/javascript">
         deform.addCallback(


### PR DESCRIPTION
Sorry, my bad, #42 introduced a bug: rendering any form would raise an error when `bootstrap_form_style` wasn't provided as a kwarg to the form constructor.

This tweaks the form.pt logic to avoid assuming that `field.bootstrap_form_style` exists.
