### PR TITLE
Bug #41 : register resources to deform's resource registry

### DIFF
--- a/deform_bootstrap/__init__.py
+++ b/deform_bootstrap/__init__.py
@@ -2,6 +2,18 @@ from pkg_resources import resource_filename
 
 from deform import Form
 
+from .resources import default_resources
+
+def add_resources_to_registry():
+    """
+        Register deform_bootstrap widget specific requirements to deform's
+        default resource registry
+    """
+    registry = Form.default_resource_registry
+    for rqrt, versions in default_resources.items():
+        for version, resources in versions.items():
+            registry.set_js_resources(rqrt, version, resources.get('js'))
+            registry.set_css_resources(rqrt, version, resources.get('css'))
 
 def add_search_path():
     loader = Form.default_renderer.loader
@@ -12,4 +24,5 @@ def add_search_path():
 
 def includeme(config):
     add_search_path()
+    add_resources_to_registry()
     config.add_static_view('static-deform_bootstrap', 'deform_bootstrap:static')

--- a/deform_bootstrap/resources.py
+++ b/deform_bootstrap/resources.py
@@ -1,0 +1,8 @@
+default_resources = {
+        "chosen":{None:{'js':("jquery_chosen/chosen.jquery.js",),
+                        'css':("jquery_chosen/chosen.css",
+                                "chosen_bootstrap.css",)}
+                 },
+        "bootstrap":{None:{'js':'bootstrap.min.js',
+                           'css':'deform_bootstrap.css'}},
+        }

--- a/deform_bootstrap/tests/test_config.py
+++ b/deform_bootstrap/tests/test_config.py
@@ -7,3 +7,12 @@ def test_config_searchpath():
     from deform_bootstrap import includeme
     includeme(config)
     config.add_static_view.assert_called_once_with('static-deform_bootstrap', 'deform_bootstrap:static')
+
+def test_config_resources():
+    from deform_bootstrap import add_resources_to_registry
+    add_resources_to_registry()
+    from deform.widget import default_resource_registry
+    assert default_resource_registry((("chosen",None),)) is not None
+    assert default_resource_registry((("bootstrap", None),)) is not None
+
+


### PR DESCRIPTION
Maybe a larger work should be made on resource registration.
Here we only register resources needed to satisfy the following requirements 
- chosen
- bootstrap
