### PR TITLE
Make ChosenMultipleWidget inherit from SelectWidget

### DIFF
--- a/deform_bootstrap/widget.py
+++ b/deform_bootstrap/widget.py
@@ -165,7 +165,7 @@ class ChosenOptGroupWidget(SelectWidget):
                               values=_normalize_optgroup_choices(self.values))
 
 
-class ChosenMultipleWidget(Widget):
+class ChosenMultipleWidget(SelectWidget):
     template = 'chosen_multiple'
     values = ()
     size = 1


### PR DESCRIPTION
deform.Widget does not define readonly_template which is used in the
widget code, causing an error when using readonly mode.

I couldn't figure out why it's using Widget. If it's really necessary, let me
know and I'll close this request and create a new one with a default
template.
