### PR TITLE
Respect the autocomplete attribute for forms

### DIFF
--- a/deform_bootstrap/templates/form.pt
+++ b/deform_bootstrap/templates/form.pt
@@ -7,7 +7,9 @@
   enctype="multipart/form-data"
   accept-charset="utf-8"
   i18n:domain="deform"
-  tal:define="inline getattr(field, 'bootstrap_form_style', None) == 'form-inline'">
+  tal:define="inline getattr(field, 'bootstrap_form_style', None) == 'form-inline';
+              autocomplete autocomplete|field.autocomplete;"
+  tal:attributes="autocomplete autocomplete">
   
   <fieldset>
 


### PR DESCRIPTION
deform allows creating a form as follows:

```
>>> class MySchema(colander.Schema):
...     foo = colander.SchemaNode(colander.String())
...
>>>
>>> form = deform.Form(MySchema(), autocomplete=False)
```

The generated form should have a `autocomplete="off"` attribute set as a
result, but it was ignored by the form.pt template.

This change is inspired by the code of the form.pt template in deform
itself.
