### PR TITLE
fix resource registry

### DIFF
--- a/deform_bootstrap/__init__.py
+++ b/deform_bootstrap/__init__.py
@@ -12,8 +12,8 @@ def add_resources_to_registry():
     registry = Form.default_resource_registry
     for rqrt, versions in default_resources.items():
         for version, resources in versions.items():
-            registry.set_js_resources(rqrt, version, resources.get('js'))
-            registry.set_css_resources(rqrt, version, resources.get('css'))
+            registry.set_js_resources(rqrt, version, *resources.get('js'))
+            registry.set_css_resources(rqrt, version, *resources.get('css'))
 
 def add_search_path():
     loader = Form.default_renderer.loader

--- a/deform_bootstrap/resources.py
+++ b/deform_bootstrap/resources.py
@@ -3,6 +3,6 @@ default_resources = {
                         'css':("jquery_chosen/chosen.css",
                                 "chosen_bootstrap.css",)}
                  },
-        "bootstrap":{None:{'js':'bootstrap.min.js',
-                           'css':'deform_bootstrap.css'}},
+        "bootstrap":{None:{'js':('bootstrap.min.js',),
+                           'css':('deform_bootstrap.css',)}},
         }


### PR DESCRIPTION
Before:

```
In [8]: deform.widget.default_resource_registry.registry

...

 'chosen': {None: {'css': (('jquery_chosen/chosen.css',
     'chosen_bootstrap.css'),),
   'js': (('jquery_chosen/chosen.jquery.js',),)}},
```

After:

```
 'chosen': {None: {'css': ('jquery_chosen/chosen.css', 'chosen_bootstrap.css'),
   'js': ('jquery_chosen/chosen.jquery.js',)}},
```
