### PR TITLE
Work around broken resource_filename() on Google AppEngine

### DIFF
--- a/deform_bootstrap/__init__.py
+++ b/deform_bootstrap/__init__.py
@@ -1,8 +1,9 @@
+# -*- coding: utf-8 -*-
+
 from pkg_resources import resource_filename
-
 from deform import Form
-
 from .resources import default_resources
+
 
 def add_resources_to_registry():
     """
@@ -15,14 +16,21 @@ def add_resources_to_registry():
             registry.set_js_resources(rqrt, version, *resources.get('js'))
             registry.set_css_resources(rqrt, version, *resources.get('css'))
 
+
 def add_search_path():
     loader = Form.default_renderer.loader
-    loader.search_path = (
-        resource_filename('deform_bootstrap', 'templates'),
-        ) + loader.search_path
+    try:
+        path = resource_filename('deform_bootstrap', 'templates')
+    except ImportError:
+        # On Google AppEngine resource_filename() uses os.path.expanduser()
+        # which uses pwd which isn't available, so we work around that mess:
+        from os.path import dirname, join
+        path = join(dirname(__file__), 'templates')
+    loader.search_path = (path,) + loader.search_path
 
 
 def includeme(config):
     add_search_path()
     add_resources_to_registry()
-    config.add_static_view('static-deform_bootstrap', 'deform_bootstrap:static')
+    config.add_static_view(
+        'static-deform_bootstrap', 'deform_bootstrap:static')


### PR DESCRIPTION
On Google AppEngine, resource_filename() is broken. Here I simply avoid using it.

Here is the stacktrace for your amusement:

```
  File "lib/deform_bootstrap-0.2.6-py2.7.egg/deform_bootstrap/__init__.py", line 21, in add_search_path
    resource_filename('deform_bootstrap', 'templates'),
  File "/home/fmaia/py/google_appengine/lib/setuptools-0.6c11/pkg_resources.py", line 882, in resource_filename
    self, resource_name
  File "/home/fmaia/py/google_appengine/lib/setuptools-0.6c11/pkg_resources.py", line 1352, in get_resource_filename
    return self._extract_resource(manager, zip_path)
  File "/home/fmaia/py/google_appengine/lib/setuptools-0.6c11/pkg_resources.py", line 1359, in _extract_resource
    manager, os.path.join(zip_path, name)
  File "/home/fmaia/py/google_appengine/lib/setuptools-0.6c11/pkg_resources.py", line 1373, in _extract_resource
    self.egg_name, self._parts(zip_path)
  File "/home/fmaia/py/google_appengine/lib/setuptools-0.6c11/pkg_resources.py", line 957, in get_cache_path
    extract_path = self.extraction_path or get_default_cache()
  File "/home/fmaia/py/google_appengine/lib/setuptools-0.6c11/pkg_resources.py", line 1080, in get_default_cache
    return os.path.expanduser('~/.python-eggs')
  File "/home/fmaia/py/venvs/v7/lib/python2.7/posixpath.py", line 268, in expanduser
    import pwd
  File "/home/fmaia/py/google_appengine/google/appengine/tools/devappserver2/python/sandbox.py", line 822, in load_module
    raise ImportError('No module named %s' % fullname)
ImportError: No module named pwd
```
