### PR TITLE
Added tabbed forms

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,27 +48,37 @@ You should now be able to access the demo site at http://0.0.0.0:8521
 Using tabs in forms
 -------------------
 
-Mappings in form appear in new tabs. The mapping title is the name of the tab,
-and the data in the mapping appears inside the tab.
-Everything that isn't in a mapping appears inside a '*Default*' tab. If no
-mappings are present, there are no tabs on the form.
+To make a tabbed form, use mapping. Each mapping will appear as a new tab,
+taking the title of the mapping as the name for the tab.
+If you specify no tabs for some information, it will default to a '*Basic*'
+tab.
 
-To get a form with the tab *Default*, which has a *number* field, and the tab
-*Mapping*, which has a *name* and *date* field, use the following example. If you
-want to change the title of the tab, use `Mapping(title="New title")`
-
-    class Mapping(colander.Schema):
+    class Person(colander.Schema):
         name = colander.SchemaNode(
             colander.String(),
-            description='Content name')
-        date = colander.SchemaNode(
-            colander.Date(),
-            widget=deform.widget.DatePartsWidget(),
-            description='Content date')
-    class Schema(colander.Schema):
-        number = colander.SchemaNode(
-            colander.Integer())
-        mapping = Mapping()
+            title=_(u'Name'),
+        )
+
+        surname = colander.SchemaNode(
+            colander.String(),
+            title=_(u'Surname'),
+        )
+
+
+    class Car(colander.Schema):
+        color = colander.SchemaNode(
+            colander.String(),
+            title=u'Color',
+        )
+        horsepower = colander.SchemaNode(
+            colander.Integer(),
+            title=u"Horsepower",
+        )
+
+
+    class ClientSchema(colander.Schema):
+        person = Person(title="Person information")
+        car = Car(title="Car information")
 
 Additional widgets / getting rid of legacy stuff
 ================================================

--- a/README.rst
+++ b/README.rst
@@ -224,14 +224,14 @@ Running Selenium tests
   Success is defined as seeing output on the console that ends like this:
 
 ```
-        01:49:06.105 INFO - Started SocketListener on 0.0.0.0:4444
-        01:49:06.105 INFO - Started org.openqa.jetty.jetty.Server@7d2a1e44
+01:49:06.105 INFO - Started SocketListener on 0.0.0.0:4444
+01:49:06.105 INFO - Started org.openqa.jetty.jetty.Server@7d2a1e44
 ```
 
 * In yet another terminal, run the tests with the command:
 
 ```
-        $ bin/python deform_bootstrap/demo/test.py
+$ bin/python deform_bootstrap/demo/test.py
 ```
 
 API

--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,31 @@ looks in practice you can run these commands, assuming that you have a
 
 You should now be able to access the demo site at http://0.0.0.0:8521
 
+Using tabs in forms
+-------------------
+
+Mappings in form appear in new tabs. The mapping title is the name of the tab,
+and the data in the mapping appears inside the tab.
+Everything that isn't in a mapping appears inside a '*Default*' tab. If no
+mappings are present, there are no tabs on the form.
+
+To get a form with the tab *Default*, which has a *number* field, and the tab
+*Mapping*, which has a *name* and *date* field, use the following example. If you
+want to change the title of the tab, use `Mapping(title="New title")`
+
+    class Mapping(colander.Schema):
+        name = colander.SchemaNode(
+            colander.String(),
+            description='Content name')
+        date = colander.SchemaNode(
+            colander.Date(),
+            widget=deform.widget.DatePartsWidget(),
+            description='Content date')
+    class Schema(colander.Schema):
+        number = colander.SchemaNode(
+            colander.Integer())
+        mapping = Mapping()
+
 Additional widgets / getting rid of legacy stuff
 ================================================
 

--- a/README.rst
+++ b/README.rst
@@ -223,12 +223,16 @@ Running Selenium tests
 * In another terminal, run ``java -jar selenium-server-standalone-X.X.jar``.
   Success is defined as seeing output on the console that ends like this:
 
-  $ 01:49:06.105 INFO - Started SocketListener on 0.0.0.0:4444
-  $ 01:49:06.105 INFO - Started org.openqa.jetty.jetty.Server@7d2a1e44
+```
+01:49:06.105 INFO - Started SocketListener on 0.0.0.0:4444
+01:49:06.105 INFO - Started org.openqa.jetty.jetty.Server@7d2a1e44
+```
 
 * In yet another terminal, run the tests with the command:
 
+```bash
   $ bin/python deform_bootstrap/demo/test.py
+```
 
 API
 ===

--- a/README.rst
+++ b/README.rst
@@ -223,16 +223,15 @@ Running Selenium tests
 * In another terminal, run ``java -jar selenium-server-standalone-X.X.jar``.
   Success is defined as seeing output on the console that ends like this:
 
-```
-01:49:06.105 INFO - Started SocketListener on 0.0.0.0:4444
-01:49:06.105 INFO - Started org.openqa.jetty.jetty.Server@7d2a1e44
-```
+
+        01:49:06.105 INFO - Started SocketListener on 0.0.0.0:4444
+        01:49:06.105 INFO - Started org.openqa.jetty.jetty.Server@7d2a1e44
+
 
 * In yet another terminal, run the tests with the command:
 
-```
-$ bin/python deform_bootstrap/demo/test.py
-```
+
+        $ bin/python deform_bootstrap/demo/test.py
 
 API
 ===

--- a/README.rst
+++ b/README.rst
@@ -224,14 +224,14 @@ Running Selenium tests
   Success is defined as seeing output on the console that ends like this:
 
 ```
-01:49:06.105 INFO - Started SocketListener on 0.0.0.0:4444
-01:49:06.105 INFO - Started org.openqa.jetty.jetty.Server@7d2a1e44
+        01:49:06.105 INFO - Started SocketListener on 0.0.0.0:4444
+        01:49:06.105 INFO - Started org.openqa.jetty.jetty.Server@7d2a1e44
 ```
 
 * In yet another terminal, run the tests with the command:
 
-```bash
-  $ bin/python deform_bootstrap/demo/test.py
+```
+        $ bin/python deform_bootstrap/demo/test.py
 ```
 
 API

--- a/README.rst
+++ b/README.rst
@@ -214,9 +214,19 @@ catches up. Note, that you can still use jquery.form itself.
 Running Selenium tests
 ----------------------
 
-Follow the instructions in ``deformdemo`` to install Selenium.  Then
-install deform_bootstrap in your virtualenv and from within
-the ``deform_bootstrap`` package run this command:
+* Make sure you have a Java interpreter installed.
+
+* Download Selenium Server <http://seleniumhq.org/download/> standalone jar file.
+
+* Start the server with demo.ini.
+
+* In another terminal, run ``java -jar selenium-server-standalone-X.X.jar``.
+  Success is defined as seeing output on the console that ends like this:
+
+  $ 01:49:06.105 INFO - Started SocketListener on 0.0.0.0:4444
+  $ 01:49:06.105 INFO - Started org.openqa.jetty.jetty.Server@7d2a1e44
+
+* In yet another terminal, run the tests with the command:
 
   $ bin/python deform_bootstrap/demo/test.py
 

--- a/deform_bootstrap/static/deform_bootstrap.css
+++ b/deform_bootstrap/static/deform_bootstrap.css
@@ -1121,7 +1121,7 @@ input[type="checkbox"][readonly] {
   border-color: #c09853;
 }
 
-ul#form-tabs li.error a,
+ul.form-tabs li.error a,
 .control-group.error > label,
 .control-group.error .help-block,
 .control-group.error .help-inline {

--- a/deform_bootstrap/static/deform_bootstrap.css
+++ b/deform_bootstrap/static/deform_bootstrap.css
@@ -1121,6 +1121,7 @@ input[type="checkbox"][readonly] {
   border-color: #c09853;
 }
 
+ul#form-tabs li.error a,
 .control-group.error > label,
 .control-group.error .help-block,
 .control-group.error .help-inline {

--- a/deform_bootstrap/templates/checkbox_choice.pt
+++ b/deform_bootstrap/templates/checkbox_choice.pt
@@ -5,7 +5,7 @@
                          label_class inline and 'checkbox inline' or 'checkbox'">
       <label class="${label_class}" for="${field.oid}-${repeat.choice.index}">
         <input tal:attributes="checked value in cstruct;
-                               class field.widget.css_class"
+                               class css_class|field.widget.css_class"
                type="checkbox"
                name="checkbox"
                value="${value}"

--- a/deform_bootstrap/templates/form.pt
+++ b/deform_bootstrap/templates/form.pt
@@ -8,51 +8,88 @@
   accept-charset="utf-8"
   i18n:domain="deform"
   tal:define="inline getattr(field, 'bootstrap_form_style', None) == 'form-inline';
-              autocomplete autocomplete|field.autocomplete;"
-  tal:attributes="autocomplete autocomplete">
-  
-  <fieldset>
+              tabifyForm import: deform_bootstrap.utils.tabifyForm;
+              fields_list python: tabifyForm(field)">
 
-    <legend tal:condition="field.title">${field.title}</legend>
 
-    <input type="hidden" name="_charset_" />
-    <input type="hidden" name="__formid__" value="${field.formid}"/>
 
-    <div class="alert alert-block alert-error" tal:condition="field.error">
-      <span class="errorMsgLbl" i18n:translate="">
-        There was a problem with your submission
-      </span>
-      <br />
-      <span class="errorMsg" i18n:translate="">
-        Errors have been highlighted below
-      </span>
-      <p class="errorMsg">${field.errormsg}</p>
-    </div>
+  <!-- Hidden inputs and alerts at the top -->
+  <input type="hidden" name="_charset_" />
+  <input type="hidden" name="__formid__" value="${field.formid}"/>
 
-    <div
-        tal:define="rndr field.renderer;
-                    tmpl field.widget.item_template"
-        tal:repeat="f field.children"
-        tal:replace="structure
-                     rndr(tmpl,field=f,cstruct=cstruct.get(f.name, null))" />
+  <div class="alert alert-block alert-error" tal:condition="field.error">
+    <span class="errorMsgLbl" i18n:translate="">
+      There was a problem with your submission
+    </span>
+    <br />
+    <span class="errorMsg" i18n:translate="">
+      Errors have been highlighted below
+    </span>
+    <p class="errorMsg">${field.errormsg}</p>
+  </div>
 
-    <div tal:condition="field.buttons" tal:omit-tag="inline" class="form-actions">
-      <tal:block repeat="button field.buttons">
-        <button
-            tal:attributes="disabled button.disabled"
-            id="${field.formid+button.name}"
-            name="${button.name}"
-            type="${button.type}"
-            class="btn ${repeat.button.start and 'btn-primary' or ''} ${button.css_class}"
-            value="${button.value}">
-          <i tal:condition="hasattr(button, 'icon') and button.icon"
-                     class="${button.icon}"></i>
-          ${button.title}
-        </button>
+  <!-- Make the tabs -->
+  <tal:block tal:condition="not: fields_list.only_one">
+    <ul id="form-tabs" class="nav nav-tabs">
+
+      <!-- Show the 'default' tab only if we have some info to put in -->
+      <tal:block tal:condition="fields_list.have_default">
+        <li class="active"><a href="#default" data-toggle="tab" i18n:translate="">Default</a></li>
       </tal:block>
-    </div>
+      <!-- Add other tabs, if we don't have 'default' tab, make the first one active -->
+      <tal:block tal:repeat="mapping fields_list.other">
+        <li tal:attributes="class python: not fields_list['have_default'] and repeat['mapping'].index == 0 and 'active' or ''">
+          <a href="#${mapping.name}" data-toggle="tab">${mapping.title}</a>
+        </li>
+      </tal:block>
+    </ul>
+  </tal:block>
 
-  </fieldset>
+
+  <!-- Populate the tabs -->
+  <div id="form-tabs-content" class="tab-content">
+    <!-- If we have a default tab, this should be active -->
+    <fieldset
+      tal:attributes="class python: fields_list['have_default'] and 'tab-pane fade active in' or 'tab-pane fade'"
+      id="default">
+      <div
+          tal:define="rndr field.renderer;
+                      tmpl field.widget.item_template"
+          tal:repeat="f fields_list.default"
+          tal:replace="structure
+                       rndr(tmpl,field=f,cstruct=cstruct.get(f.name, null))" />
+    </fieldset>
+    <!-- If we don't have a default tab, the first one here should be active -->
+    <tal:block tal:repeat="mapping fields_list.other">
+      <fieldset
+        tal:attributes="class python: not fields_list['have_default'] and repeat['mapping'].index == 0 and 'tab-pane face active in' or 'tab-pane face'"
+        id="${mapping.name}">
+        <div
+          tal:define="rndr field.renderer;
+                      tmpl field.widget.item_template"
+          tal:replace="structure
+                       rndr(tmpl,field=mapping.children,cstruct=cstruct.get(mapping.name, null))" />
+      </fieldset>
+    </tal:block>
+
+  </div>
+
+  <!-- Append the buttons at the end -->
+  <div tal:condition="field.buttons" tal:omit-tag="inline" class="form-actions">
+    <tal:block repeat="button field.buttons">
+      <button
+          tal:attributes="disabled button.disabled"
+          id="${field.formid+button.name}"
+          name="${button.name}"
+          type="${button.type}"
+          class="btn ${repeat.button.start and 'btn-primary' or ''} ${button.css_class}"
+          value="${button.value}">
+        <i tal:condition="hasattr(button, 'icon') and button.icon"
+                   class="${button.icon}"></i>
+        ${button.title}
+      </button>
+    </tal:block>
+  </div>
 
   <script type="text/javascript" tal:condition="field.use_ajax">
     deform.addCallback(
@@ -71,5 +108,5 @@
        }
     );
   </script>
-  
+
 </form>

--- a/deform_bootstrap/templates/form.pt
+++ b/deform_bootstrap/templates/form.pt
@@ -8,8 +8,10 @@
   accept-charset="utf-8"
   i18n:domain="deform"
   tal:define="inline getattr(field, 'bootstrap_form_style', None) == 'form-inline';
-              tabifyForm import: deform_bootstrap.utils.tabifyForm;
-              fields_list python: tabifyForm(field)">
+              tabify_form import: deform_bootstrap.utils.tabify_form;
+              fields_list python: tabify_form(field);
+              autocomplete autocomplete|field.autocomplete;"
+  tal:attributes="autocomplete autocomplete">
 
 
 
@@ -32,14 +34,14 @@
   <tal:block tal:condition="not: fields_list.only_one">
     <ul id="form-tabs" class="nav nav-tabs">
 
-      <!-- Show the 'default' tab only if we have some info to put in -->
-      <tal:block tal:condition="fields_list.have_default">
-        <li class="active" id="default-list"><a href="#default" data-toggle="tab" i18n:translate="">Default</a></li>
+      <!-- Show the 'basic' tab only if we have some info to put in -->
+      <tal:block tal:condition="fields_list.have_basic">
+        <li class="active" id="basic-list"><a href="#basic" data-toggle="tab" i18n:translate="">Basic</a></li>
       </tal:block>
-      <!-- Add other tabs, if we don't have 'default' tab, make the first one active -->
+      <!-- Add other tabs, if we don't have 'basic' tab, make the first one active -->
       <tal:block tal:repeat="mapping fields_list.other">
         <li id="${mapping.name}-list"
-            tal:attributes="class python: not fields_list['have_default'] and repeat['mapping'].index == 0 and 'active' or ''">
+            tal:attributes="class python: not fields_list['have_basic'] and repeat['mapping'].index == 0 and 'active' or ''">
           <a href="#${mapping.name}" data-toggle="tab">${mapping.title}</a>
         </li>
       </tal:block>
@@ -49,21 +51,21 @@
 
   <!-- Populate the tabs -->
   <div id="form-tabs-content" class="tab-content">
-    <!-- If we have a default tab, this should be active -->
+    <!-- If we have a basic tab, this should be active -->
     <fieldset
-      tal:attributes="class python: fields_list['have_default'] and 'tab-pane fade active in' or 'tab-pane fade'"
-      id="default">
+      tal:attributes="class python: fields_list['have_basic'] and 'tab-pane fade active in' or 'tab-pane fade'"
+      id="basic">
       <div
           tal:define="rndr field.renderer;
                       tmpl field.widget.item_template"
-          tal:repeat="f fields_list.default"
+          tal:repeat="f fields_list.basic"
           tal:replace="structure
                        rndr(tmpl,field=f,cstruct=cstruct.get(f.name, null))" />
     </fieldset>
-    <!-- If we don't have a default tab, the first one here should be active -->
+    <!-- If we don't have a basic tab, the first one here should be active -->
     <tal:block tal:repeat="mapping fields_list.other">
       <fieldset
-        tal:attributes="class python: not fields_list['have_default'] and repeat['mapping'].index == 0 and 'tab-pane face active in' or 'tab-pane face'"
+        tal:attributes="class python: not fields_list['have_basic'] and repeat['mapping'].index == 0 and 'tab-pane face active in' or 'tab-pane face'"
         id="${mapping.name}">
         <div
           tal:define="rndr field.renderer;
@@ -121,13 +123,14 @@
           $("ul#form-tabs li.active").removeClass('active');
           $("div#form-tabs-content fieldset.active").removeClass('active in');
         }
-        // Go through the errors, set first one to active, and add an 'error'
-        // class to all of the tabs with errors in them
+        // Go through the errors, set first one to active and focus the field,
+        // and add an 'error' class to all of the tabs with errors in them
         $("div#form-tabs-content fieldset div.error").each( function() {
           var errorId = $(this.parentNode).attr('id');
           if(!alreadySelected){
             $("ul#form-tabs li#" + errorId + '-list').addClass('active');
             $("div#form-tabs-content fieldset#" + errorId).addClass('active in');
+            $("#" + $(this).attr('id') + " div.controls input").focus();
             alreadySelected = true;
           }
           $("ul#form-tabs li#" +errorId + '-list').addClass('error');

--- a/deform_bootstrap/templates/form.pt
+++ b/deform_bootstrap/templates/form.pt
@@ -32,7 +32,7 @@
 
   <!-- Make the tabs -->
   <tal:block tal:condition="not: fields_list.only_one">
-    <ul id="form-tabs" class="nav nav-tabs">
+    <ul class="nav nav-tabs form-tabs">
 
       <!-- Show the 'basic' tab only if we have some info to put in -->
       <tal:block tal:condition="fields_list.have_basic">
@@ -50,7 +50,7 @@
 
 
   <!-- Populate the tabs -->
-  <div id="form-tabs-content" class="tab-content">
+  <div class="tab-content">
     <!-- If we have a basic tab, this should be active -->
     <fieldset
       tal:attributes="class python: fields_list['have_basic'] and 'tab-pane fade active in' or 'tab-pane fade'"
@@ -119,21 +119,21 @@
         var alreadySelected = false;
 
         // If we get some errors, remove the active classes
-        if($("div#form-tabs-content fieldset div.error").length !== 0){
-          $("ul#form-tabs li.active").removeClass('active');
-          $("div#form-tabs-content fieldset.active").removeClass('active in');
+        if($("div.tab-content fieldset div.error").length !== 0){
+          $("ul.form-tabs li.active").removeClass('active');
+          $("div.tab-content fieldset.active").removeClass('active in');
         }
         // Go through the errors, set first one to active and focus the field,
         // and add an 'error' class to all of the tabs with errors in them
-        $("div#form-tabs-content fieldset div.error").each( function() {
+        $("div.tab-content fieldset div.error").each( function() {
           var errorId = $(this.parentNode).attr('id');
           if(!alreadySelected){
-            $("ul#form-tabs li#" + errorId + '-list').addClass('active');
-            $("div#form-tabs-content fieldset#" + errorId).addClass('active in');
+            $("ul.form-tabs li#" + errorId + '-list').addClass('active');
+            $("div.tab-content fieldset#" + errorId).addClass('active in');
             $("#" + $(this).attr('id') + " div.controls input").focus();
             alreadySelected = true;
           }
-          $("ul#form-tabs li#" +errorId + '-list').addClass('error');
+          $("ul.form-tabs li#" +errorId + '-list').addClass('error');
         });
     });
   </script>

--- a/deform_bootstrap/templates/form.pt
+++ b/deform_bootstrap/templates/form.pt
@@ -34,11 +34,12 @@
 
       <!-- Show the 'default' tab only if we have some info to put in -->
       <tal:block tal:condition="fields_list.have_default">
-        <li class="active"><a href="#default" data-toggle="tab" i18n:translate="">Default</a></li>
+        <li class="active" id="default-list"><a href="#default" data-toggle="tab" i18n:translate="">Default</a></li>
       </tal:block>
       <!-- Add other tabs, if we don't have 'default' tab, make the first one active -->
       <tal:block tal:repeat="mapping fields_list.other">
-        <li tal:attributes="class python: not fields_list['have_default'] and repeat['mapping'].index == 0 and 'active' or ''">
+        <li id="${mapping.name}-list"
+            tal:attributes="class python: not fields_list['have_default'] and repeat['mapping'].index == 0 and 'active' or ''">
           <a href="#${mapping.name}" data-toggle="tab">${mapping.title}</a>
         </li>
       </tal:block>
@@ -107,6 +108,31 @@
          $('#' + oid).ajaxForm($.extend(options, extra_options));
        }
     );
+  </script>
+  <script>
+    // Highlight all tabs with errors, move to the first one with the error
+    deform.addCallback(
+       '${field.formid}',
+       function() {
+        var alreadySelected = false;
+
+        // If we get some errors, remove the active classes
+        if($("div#form-tabs-content fieldset div.error").length !== 0){
+          $("ul#form-tabs li.active").removeClass('active');
+          $("div#form-tabs-content fieldset.active").removeClass('active in');
+        }
+        // Go through the errors, set first one to active, and add an 'error'
+        // class to all of the tabs with errors in them
+        $("div#form-tabs-content fieldset div.error").each( function() {
+          var errorId = $(this.parentNode).attr('id');
+          if(!alreadySelected){
+            $("ul#form-tabs li#" + errorId + '-list').addClass('active');
+            $("div#form-tabs-content fieldset#" + errorId).addClass('active in');
+            alreadySelected = true;
+          }
+          $("ul#form-tabs li#" +errorId + '-list').addClass('error');
+        });
+    });
   </script>
 
 </form>

--- a/deform_bootstrap/templates/mapping.pt
+++ b/deform_bootstrap/templates/mapping.pt
@@ -2,15 +2,13 @@
 
   <input type="hidden" name="__start__" value="${field.name}:mapping"/>
 
-  <legend tal:condition="field.title">${field.title}</legend>
-
   <div class="clearfix alert alert-message error" tal:condition="field.errormsg">
     <p i18n:translate="">
       There was a problem with this section
     </p>
     <p>${field.errormsg}</p>
   </div>
-  
+
   <div tal:condition="field.description">
     ${field.description}
   </div>

--- a/deform_bootstrap/templates/mapping.pt
+++ b/deform_bootstrap/templates/mapping.pt
@@ -1,5 +1,3 @@
-<fieldset i18n:domain="deform">
-
   <input type="hidden" name="__start__" value="${field.name}:mapping"/>
 
   <div class="clearfix alert alert-message error" tal:condition="field.errormsg">
@@ -11,8 +9,6 @@
 
   <div tal:condition="field.description">
     ${field.description}
-  </div>
-
   <div
       tal:define="rndr field.renderer;
                   tmpl field.widget.item_template"
@@ -20,5 +16,3 @@
       tal:replace="structure rndr(tmpl,field=f,cstruct=cstruct.get(f.name,null))" />
 
   <input type="hidden" name="__end__" value="${field.name}:mapping"/>
-
-</fieldset>

--- a/deform_bootstrap/templates/radio_choice.pt
+++ b/deform_bootstrap/templates/radio_choice.pt
@@ -1,5 +1,5 @@
 <input type="hidden" name="__start__" value="${field.name}:rename"/>
-<tal:loop tal:repeat="choice field.widget.values">
+<tal:loop tal:repeat="choice values | field.widget.values">
   <tal:def tal:define="(value, title) choice;
                        inline getattr(field.widget, 'inline', False);
                        label_class inline and 'radio inline' or 'radio'">

--- a/deform_bootstrap/tests/test_form.py
+++ b/deform_bootstrap/tests/test_form.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from deform.tests.test_schema import DummySchemaNode
+from deform.widget import TextAreaWidget
+import unittest
+import colander
+
+
+class DummyForm(object):
+    def __init__(self, children=[]):
+        self.children = children
+
+
+class DummyField(object):
+    def __init__(self, title, name, children=[]):
+        self.title = title
+        self.name = name
+        self.children = children
+
+
+class TestSet(unittest.TestCase):
+    def setUp(self):
+        from zope.deprecation import __show__
+        __show__.off()
+
+    def tearDown(self):
+        from zope.deprecation import __show__
+        __show__.on()
+
+    def _makeOne(self, **kw):
+        from deform.schema import Set
+        return Set(**kw)
+
+    def test_tabifyForm_empty(self):
+        from deform_bootstrap.utils import tabifyForm
+
+        form = DummyForm()
+
+        result = tabifyForm(form)
+        expected_result = {
+            'default': [],
+            'other': [],
+            'only_one': True,
+            'have_default': False,
+        }
+        self.assertEqual(result, expected_result)
+
+    def test_tabifyForm_no_mappings(self):
+        from deform_bootstrap.utils import tabifyForm
+        children = [
+            DummyField("Title", "title"),
+            DummyField("Description", "description")
+        ]
+        form = DummyForm(children)
+
+        result = tabifyForm(form)
+        expected_result = {
+            'default': children,
+            'other': [],
+            'only_one': True,
+            'have_default': True,
+        }
+        self.assertEqual(result, expected_result)
+
+    def test_tabifyForm_mappings(self):
+        from deform_bootstrap.utils import tabifyForm
+        children = [
+            DummyField("Title", "title"),
+            DummyField("Description", "description")
+        ]
+        mappings = [
+            DummyField("Mapping", "mapping", [
+                DummyField("Name", "name"),
+                DummyField("Phone number", "phone-number")
+            ])
+        ]
+
+        form = DummyForm(children + mappings)
+
+        result = tabifyForm(form)
+        expected_result = {
+            'default': children,
+            'other': [{'title': "Mapping",
+                       'name': "mapping",
+                       'children': mappings[0],
+                       }],
+            'only_one': False,
+            'have_default': True,
+        }
+        self.assertEqual(result, expected_result)
+
+    def test_tabifyForm_mappings_no_default(self):
+        from deform_bootstrap.utils import tabifyForm
+        mappings = [
+            DummyField("Mapping", "mapping", [
+                DummyField("Name", "name"),
+                DummyField("Phone number", "phone-number")
+            ])
+        ]
+
+        form = DummyForm(mappings)
+
+        result = tabifyForm(form)
+        expected_result = {
+            'default': [],
+            'other': [{'title': "Mapping",
+                       'name': "mapping",
+                       'children': mappings[0],
+                       }],
+            'only_one': False,
+            'have_default': False,
+        }
+        self.assertEqual(result, expected_result)

--- a/deform_bootstrap/tests/test_form.py
+++ b/deform_bootstrap/tests/test_form.py
@@ -32,39 +32,39 @@ class TestSet(unittest.TestCase):
         from deform.schema import Set
         return Set(**kw)
 
-    def test_tabifyForm_empty(self):
-        from deform_bootstrap.utils import tabifyForm
+    def test_tabify_form_empty(self):
+        from deform_bootstrap.utils import tabify_form
 
         form = DummyForm()
 
-        result = tabifyForm(form)
+        result = tabify_form(form)
         expected_result = {
-            'default': [],
+            'basic': [],
             'other': [],
             'only_one': True,
-            'have_default': False,
+            'have_basic': False,
         }
         self.assertEqual(result, expected_result)
 
-    def test_tabifyForm_no_mappings(self):
-        from deform_bootstrap.utils import tabifyForm
+    def test_tabify_form_no_mappings(self):
+        from deform_bootstrap.utils import tabify_form
         children = [
             DummyField("Title", "title"),
             DummyField("Description", "description")
         ]
         form = DummyForm(children)
 
-        result = tabifyForm(form)
+        result = tabify_form(form)
         expected_result = {
-            'default': children,
+            'basic': children,
             'other': [],
             'only_one': True,
-            'have_default': True,
+            'have_basic': True,
         }
         self.assertEqual(result, expected_result)
 
-    def test_tabifyForm_mappings(self):
-        from deform_bootstrap.utils import tabifyForm
+    def test_tabify_form_mappings(self):
+        from deform_bootstrap.utils import tabify_form
         children = [
             DummyField("Title", "title"),
             DummyField("Description", "description")
@@ -78,20 +78,20 @@ class TestSet(unittest.TestCase):
 
         form = DummyForm(children + mappings)
 
-        result = tabifyForm(form)
+        result = tabify_form(form)
         expected_result = {
-            'default': children,
+            'basic': children,
             'other': [{'title': "Mapping",
                        'name': "mapping",
                        'children': mappings[0],
                        }],
             'only_one': False,
-            'have_default': True,
+            'have_basic': True,
         }
         self.assertEqual(result, expected_result)
 
-    def test_tabifyForm_mappings_no_default(self):
-        from deform_bootstrap.utils import tabifyForm
+    def test_tabify_form_mappings_no_basic(self):
+        from deform_bootstrap.utils import tabify_form
         mappings = [
             DummyField("Mapping", "mapping", typ=colander.Mapping(), children=[
                 DummyField("Name", "name"),
@@ -101,14 +101,14 @@ class TestSet(unittest.TestCase):
 
         form = DummyForm(mappings)
 
-        result = tabifyForm(form)
+        result = tabify_form(form)
         expected_result = {
-            'default': [],
+            'basic': [],
             'other': [{'title': "Mapping",
                        'name': "mapping",
                        'children': mappings[0],
                        }],
             'only_one': False,
-            'have_default': False,
+            'have_basic': False,
         }
         self.assertEqual(result, expected_result)

--- a/deform_bootstrap/tests/test_form.py
+++ b/deform_bootstrap/tests/test_form.py
@@ -1,22 +1,22 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from deform.tests.test_schema import DummySchemaNode
-from deform.widget import TextAreaWidget
 import unittest
 import colander
 
 
 class DummyForm(object):
-    def __init__(self, children=[]):
+    def __init__(self, children=[], typ=colander.String()):
         self.children = children
+        self.typ = typ
 
 
 class DummyField(object):
-    def __init__(self, title, name, children=[]):
+    def __init__(self, title, name, children=[], typ=colander.String()):
         self.title = title
         self.name = name
         self.children = children
+        self.typ = typ
 
 
 class TestSet(unittest.TestCase):
@@ -70,7 +70,7 @@ class TestSet(unittest.TestCase):
             DummyField("Description", "description")
         ]
         mappings = [
-            DummyField("Mapping", "mapping", [
+            DummyField("Mapping", "mapping", typ=colander.Mapping(), children=[
                 DummyField("Name", "name"),
                 DummyField("Phone number", "phone-number")
             ])
@@ -93,7 +93,7 @@ class TestSet(unittest.TestCase):
     def test_tabifyForm_mappings_no_default(self):
         from deform_bootstrap.utils import tabifyForm
         mappings = [
-            DummyField("Mapping", "mapping", [
+            DummyField("Mapping", "mapping", typ=colander.Mapping(), children=[
                 DummyField("Name", "name"),
                 DummyField("Phone number", "phone-number")
             ])

--- a/deform_bootstrap/utils.py
+++ b/deform_bootstrap/utils.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from colander import Mapping
 
 def tabifyForm(form):
     """
@@ -11,7 +12,7 @@ def tabifyForm(form):
     mappings = []
 
     for i in form.children:
-        if i.children:
+        if type(i.typ) is Mapping:
             mappings.append({'title': i.title,
                              'name': i.name,
                              'children': i,

--- a/deform_bootstrap/utils.py
+++ b/deform_bootstrap/utils.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+def tabifyForm(form):
+    """
+        A function that returns data from the form in a nice way ready for
+        tabbed view.
+    """
+    children = []
+    mappings = []
+
+    for i in form.children:
+        if i.children:
+            mappings.append({'title': i.title,
+                             'name': i.name,
+                             'children': i,
+                             })
+        else:
+            children.append(i)
+
+    return {
+        'default': children,
+        'other': mappings,
+        'only_one': mappings == [],
+        'have_default': len(children) > 1
+    }

--- a/deform_bootstrap/utils.py
+++ b/deform_bootstrap/utils.py
@@ -4,7 +4,7 @@
 from colander import Mapping
 
 
-def tabifyForm(form):
+def tabify_form(form):
     """
         A function that returns data from the form in a nice way ready for
         tabbed view.
@@ -21,8 +21,8 @@ def tabifyForm(form):
             children.append(i)
 
     return {
-        'default': children,
+        'basic': children,
         'other': mappings,
         'only_one': mappings == [],
-        'have_default': len(children) > 1 or len(children) == 1 and children[0].name != 'csrf_token'
+        'have_basic': len(children) > 1 or len(children) == 1 and children[0].name != 'csrf_token'
     }

--- a/deform_bootstrap/utils.py
+++ b/deform_bootstrap/utils.py
@@ -23,5 +23,5 @@ def tabifyForm(form):
         'default': children,
         'other': mappings,
         'only_one': mappings == [],
-        'have_default': len(children) > 1
+        'have_default': len(children) > 1 or len(children) == 1 and children[0].name != 'csrf_token'
     }

--- a/deform_bootstrap/utils.py
+++ b/deform_bootstrap/utils.py
@@ -3,6 +3,7 @@
 
 from colander import Mapping
 
+
 def tabifyForm(form):
     """
         A function that returns data from the form in a nice way ready for
@@ -10,7 +11,6 @@ def tabifyForm(form):
     """
     children = []
     mappings = []
-
     for i in form.children:
         if type(i.typ) is Mapping:
             mappings.append({'title': i.title,


### PR DESCRIPTION
Added option to add tabs to forms, using colander.Mapping() (each Mapping appears in a new tab on the form). 

Form validation is changed so all forms with errors are highlighted, and the first tab with errors is automatically selected. Also fixed some problems with radio widgets using integers as ID's, fixing two problems in selenium tests on the way.

Added basic info about adding tabbed forms into the README. 
