### PR TITLE
pull request for Issue #59:  readonly textinput fields

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,8 @@ CHANGES
 - add bootstrap iconglyphs and fix deform_bootstrap.css to point to 
   them. See #61
 
+- add readonly textinput that uses bootstrap styling
+
 0.2.8 - 2013-06-25
 ------------------
 
@@ -20,7 +22,7 @@ CHANGES
 0.2.7 - 2013-05-04
 ------------------
 
-- Add suuport for Py3k.  See #55.
+- Add support for Py3k.  See #55.
 
 - Improve test coverage.  See #55.
 

--- a/README.rst
+++ b/README.rst
@@ -233,6 +233,7 @@ Information for developers / contributors
 
 Running unit tests
 ------------------
+::
 
   $ bin/python setup.py dev
   $ bin/py.test

--- a/deform_bootstrap/templates/readonly/textinput.pt
+++ b/deform_bootstrap/templates/readonly/textinput.pt
@@ -1,0 +1,10 @@
+<span tal:define="css_class css_class|field.widget.css_class;
+                  oid oid|field.oid;
+                  style style|field.widget.style|None"
+      tal:omit-tag="">
+    <span tal:attributes="class string:uneditable-input ${css_class};
+                          style style"
+          id="${oid}">
+              ${cstruct}
+    </span>
+</span>


### PR DESCRIPTION
I tried to match the formatting used in the other templates and ran the tests with no issues.

You can see it in action in the `/readonly_value_nonvalidation` demo.  It looks better with Bootstrap 2.3 as it better matches the width of the regular editable form input.
